### PR TITLE
Add Nix installation to update-vendor-deps workflow

### DIFF
--- a/.github/workflows/update-vendor-deps.yml
+++ b/.github/workflows/update-vendor-deps.yml
@@ -15,6 +15,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
       - name: Update vendored deps
         run: |
           ./scripts/update-vendored-deps.sh


### PR DESCRIPTION

Fixes the workflow failure by installing Nix before running the
update-vendored-deps.sh script which requires nix-shell.