### PR TITLE
Use Node.js 24 runtime

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 21]
+        node-version: [20, 24]
 
     steps:
       - uses: actions/checkout@v7

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
   success:
     description: '"true" if the commit meets the criteria'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'git-merge'


### PR DESCRIPTION
GitHub Actions is moving JavaScript actions away from the deprecated Node.js 20 runtime, so this updates the action metadata to use Node.js 24 and replaces EOL Node.js 21 in the CI matrix with Node.js 24 while retaining Node.js 20 compatibility. npm run prettier, npm run lint, npm run build, and git diff --check pass.