### PR TITLE
Skip user lookup when approval is disabled

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38527,12 +38527,14 @@ function run() {
                         },
                     });
                     maybeAuthenticatedUser = null;
+                    if (!approve) return [3 /*break*/, 4];
                     _a.label = 1;
                 case 1:
                     _a.trys.push([1, 3, , 4]);
                     return [4 /*yield*/, octokit.rest.users.getAuthenticated()];
                 case 2:
-                    maybeAuthenticatedUser = (_a.sent()).data;
+                    maybeAuthenticatedUser = (_a.sent())
+                        .data;
                     core_debug("Authenticated user: ".concat(maybeAuthenticatedUser.id));
                     return [3 /*break*/, 4];
                 case 3:

--- a/src/run.ts
+++ b/src/run.ts
@@ -105,13 +105,16 @@ export async function run(): Promise<Result> {
       >['data']
     | null = null;
 
-  try {
-    maybeAuthenticatedUser = (await octokit.rest.users.getAuthenticated()).data;
-    core.debug(`Authenticated user: ${maybeAuthenticatedUser.id}`);
-  } catch (e) {
-    core.warning('Error fetching authenticated user');
-    if (core.isDebug() && (e instanceof Error || typeof e === 'string')) {
-      core.warning(e);
+  if (approve) {
+    try {
+      maybeAuthenticatedUser = (await octokit.rest.users.getAuthenticated())
+        .data;
+      core.debug(`Authenticated user: ${maybeAuthenticatedUser.id}`);
+    } catch (e) {
+      core.warning('Error fetching authenticated user');
+      if (core.isDebug() && (e instanceof Error || typeof e === 'string')) {
+        core.warning(e);
+      }
     }
   }
   const enableAutoMerge = async (): Promise<


### PR DESCRIPTION
When approval is disabled, the authenticated-user result is never used, but the action still calls GET /user. Tokens that do not represent a user, including GitHub App installation tokens such as github.token, therefore produce a warning even though auto-merge succeeds normally. This gates the lookup on approve and regenerates the committed bundle.